### PR TITLE
nit: Fix boolean withContent in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ const editor = new Editor({
 });
 
 // Duplicate the current column with content
-editor.commands.duplicateColumn(false);
+editor.commands.duplicateColumn(true);
 
 // Duplicate the current row without content
 editor.commands.duplicateRow(false);


### PR DESCRIPTION
A tat nitpicky, but `withContent` should be set to `true` in the 1st case 😃 