### PR TITLE
fix: change column resize handle z-index to prevent overlap with modals

### DIFF
--- a/src/pagination/TablePlusNodeView.ts
+++ b/src/pagination/TablePlusNodeView.ts
@@ -106,7 +106,7 @@ export class TablePlusNodeView {
         handle.style.top = "50%";
         handle.style.width = "12px";
         handle.style.height = "12px";
-        handle.style.zIndex = "9999";
+        handle.style.zIndex = "auto";
         handle.style.borderRadius = "50%";
         handle.style.transform = "translate(-50%, -50%)";
         handle.style.cursor = "ew-resize";


### PR DESCRIPTION
## Problem

The column resize handles on tables have `z-index: 9999`, which causes them to appear above modal overlays and dialogs (e.g., the "Edit Header & Footer" modal in the pagination demo).

## Root Cause

In `src/pagination/TablePlusNodeView.ts` line 109, the handle element is styled with `zIndex = "9999"`. Since the handle is `position: absolute` inside a `position: relative` slider, it only needs to be positioned relative to its parent — not above the entire page.

## Fix

Changed `handle.style.zIndex` from `"9999"` to `"auto"`. The handle is already `position: absolute` inside the slider container, so an explicit high z-index is unnecessary and causes stacking context issues with overlays.

## Testing

- Verified that column resize handles still work correctly (drag to resize)
- Verified that modals/overlays now properly cover the handles
- Tested on the tiptap-pagination demo site

[BEFORE]
<img width="1946" height="1244" alt="image" src="https://github.com/user-attachments/assets/d31c7d01-ec91-43d3-8f05-97fb4525d525" />

[AFTER]
<img width="1946" height="1244" alt="image" src="https://github.com/user-attachments/assets/c0b41a2f-52bd-4842-920e-cfc1e7f6105c" />
