### PR TITLE
fix: correct percent-to-pixel conversion in resize handle min-width clamp

### DIFF
--- a/src/pagination/TablePlusNodeView.ts
+++ b/src/pagination/TablePlusNodeView.ts
@@ -56,7 +56,7 @@ export class TablePlusNodeView {
         let percent = Math.min(Math.max((x / rect.width) * 100, 0), 100);
 
         if (handleIndex > 0) {
-          let previousPixel = (parseFloat(this.handles[handleIndex - 1].style.left) * x / percent) + this.options.minColumnSize;
+          let previousPixel = (parseFloat(this.handles[handleIndex - 1].style.left) * rect.width / 100) + this.options.minColumnSize;
           if(x < previousPixel) {
             percent = Math.min(Math.max((previousPixel / rect.width) * 100, 0), 100);
           }
@@ -66,7 +66,7 @@ export class TablePlusNodeView {
           );
         }
         if (handleIndex < this.handles.length - 1) {
-          let nextPixel = (parseFloat(this.handles[handleIndex + 1].style.left) * x / percent) - this.options.minColumnSize;
+          let nextPixel = (parseFloat(this.handles[handleIndex + 1].style.left) * rect.width / 100) - this.options.minColumnSize;
           if(x > nextPixel) {
             percent = Math.min(Math.max((nextPixel / rect.width) * 100, 0), 100);
           }


### PR DESCRIPTION
## Issue

In `TablePlusNodeView`'s column resize handler (`onMouseMove`), the min-width clamp against adjacent handles converts a neighbor's stored `left%` to pixels using:

```js
parseFloat(handles[i].style.left) * x / percent
```

`x` (mouse position in px) has no upper bound, but percent is clamped to [0, 100].

This works, but only if it's within the table bounds (`x <= rect.width` and `x / percent` happens to equal `rect.width / 100`). But once the cursor is dragged past the table's right edge, `x > rect.width` while `percent` stays capped at 100, so `x / percent` overshoots the real "pixels per 1%" ratio.

As a result, the min-width boundary is wrongly calculated, allowing the adjacent column to be squeezed below `minColumnSize`, even down to 0px in the worst case (the dragged handle ends up landing exactly on top of its neighbor).

**Repro:** (see r1 below for demo from https://tiptapplus.com/table-plus/pagination-resize/)

1. Create a table with 3+ columns.
2. Drag the resize handle of a column past the table's right edge.
3. Observe the adjacent column shrinks below the configured minColumnSize (collapses to 0px).

## Fix

Replace `x / percent` with the constant conversion factor `rect.width / 100` ("pixels per 1%") in both the previous-handle and next-handle clamp calculations:

This makes the boundary calculation independent of the dragged handle's own (potentially out-of-bounds) pixel position, so `minColumnSize` is enforced correctly even when dragging past the table edges.


## Assets

r1

Here we can see the next column collapsing instead of stopping at the minimum width when a handle is dragged past the right edge of the table.

https://github.com/user-attachments/assets/414aef97-606b-4529-aea0-b712064791c1
